### PR TITLE
Add option to check version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # lFinder
-An open source command line interface link checker written in node.js that will look for dead links with support for .txt, .html and .doc files.  
+
+An open source command line interface link checker written in node.js that will look for dead links with support for .txt, .html and .doc files.
 
 ---
+
 # Features
+
 - Coloured text cleanly shows what urls are good or bad in your system
   - Good links (200 status) are in green
   - Checks for bad 404 and 400 errors in bright red
@@ -12,28 +15,32 @@ An open source command line interface link checker written in node.js that will 
 - Asyncronous functionality speeds up checking
 
 ---
+
 # Installation
+
 1. Ensure you have node.js installed on your computer
 2. Download the tool as a zip or clone it
 3. Open up a command line terminal and go into the folder with the tool
 4. Run command npm -install -g to install globally while inside the folder  
-**===ALTERNATIVLEY===**   
-Run command npm install -g https://github.com/Supercraft888/lFinder.git which should install it from github itself globally
+   **===ALTERNATIVLEY===**  
+   Run command npm install -g https://github.com/Supercraft888/lFinder.git which should install it from github itself globally
 
 **To uninstall use a command line terminal and enter npm uninstall -g lFinder**
 
 ---
+
 # Instructions
 
-To run in your command window type: ```lFinder -n <name of the file>```  Replace <name of file> with the location of file from current directory if necessary.  Other viable prompts are --name.
-  
-To see which version type ```lFinder --version```
+To run in your command window type: `lFinder -n <name of the file>` Replace <name of file> with the location of file from current directory if necessary. Other viable prompts are --name.
 
-To see viable commands type ```lFinder --help```
+To see which version type `lFinder --version` or `lFinder -v`
+
+To see viable commands type `lFinder --help`
 
 You can ignore the testing files, they are not necessary.
 
 # License
+
 ISC License
 Copyright (c) 2020, Alexander Hugh
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -13,26 +13,51 @@ const fs = require("fs");
 const fetch = require("node-fetch");
 const { url } = require("inspector");
 const { count } = require("console");
+const v = require("../package.json").version;
+
+//Making box for text, not necessary in the long run.
+const boxenOptions = {
+  padding: 1,
+  margin: 1,
+  borderStyle: "round",
+  borderColor: "green",
+  backgroundColor: "#555555",
+};
 
 const regexForURLs = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/gi;
 
-let lineArray = [];         //Array for each line of the file
-let lineWithURLArray = [];  //Array for lines with URLs
-let onlyURLArray = [];      //Array for each individual url
-let uniqueURLArray = [];    //Array for unique urls from onlyURLArray
+let lineArray = []; //Array for each line of the file
+let lineWithURLArray = []; //Array for lines with URLs
+let onlyURLArray = []; //Array for each individual url
+let uniqueURLArray = []; //Array for unique urls from onlyURLArray
 
-//Array for urls that 
+//Array for urls that
 //THIS CAN BE UPDATED AT ANYTIME
-let systemURLs = ["http://schemas.microsoft.com/office/2004/12/omml", "http://www.w3.org/TR/REC-html40", "http://schemas.openxmlformats.org/drawingml/2006/main"];
+let systemURLs = [
+  "http://schemas.microsoft.com/office/2004/12/omml",
+  "http://www.w3.org/TR/REC-html40",
+  "http://schemas.openxmlformats.org/drawingml/2006/main",
+];
+
+//Customize tool name and version inside the box
+const vmessage = chalk.white.bold(`lFinder version: ${v}`);
+const versionBox = boxen(vmessage, boxenOptions);
 
 //This is the argument passer
 const options = yargs
   .usage("Usage: -n <name>")
-  .option("n", { alias: "name", describe: "enter the full name of the file including file type", type: "string", demandOption: true })
-  .argv;
+  .option("n", {
+    alias: "name",
+    describe: "enter the full name of the file including file type",
+    type: "string",
+    demandOption: true,
+  })
+  .alias("v", "version")
+  .version(`${versionBox}`)
+  .describe("version", "show version information").argv;
 
 //how to read the file entered in the argument
-fs.readFile(options.name, 'utf8', function (err, data) {
+fs.readFile(options.name, "utf8", function (err, data) {
   if (err) {
     console.log(err);
   } else {
@@ -42,11 +67,21 @@ fs.readFile(options.name, 'utf8', function (err, data) {
 
     //goes through "lineArray" and uses the filter method to find lines with http and https in them.
     //Also removes lines that do NOT have urls in them so that we wont wate time on those using our regex on them.
-    //Then puts the lines with http and https (with all capitals too) in "lineWithURLArray" 
-    lineWithURLArray = lineArray.filter(line => line.includes("https:") || line.includes("http:") || line.includes("HTTPS:") || line.includes("HTTP:"));
-    console.log("The number of lines with URLs in this file: ", lineWithURLArray.length, "\n");
+    //Then puts the lines with http and https (with all capitals too) in "lineWithURLArray"
+    lineWithURLArray = lineArray.filter(
+      (line) =>
+        line.includes("https:") ||
+        line.includes("http:") ||
+        line.includes("HTTPS:") ||
+        line.includes("HTTP:")
+    );
+    console.log(
+      "The number of lines with URLs in this file: ",
+      lineWithURLArray.length,
+      "\n"
+    );
 
-    console.log("Checking for the number of URL's in this file...\n")
+    console.log("Checking for the number of URL's in this file...\n");
 
     //goes through the "lineWithURLArray" and finds things that match the regex.  Then puts them into onlyURLArray made at line 21-ish
     for (let i = 0; i < lineWithURLArray.length; i++) {
@@ -54,7 +89,7 @@ fs.readFile(options.name, 'utf8', function (err, data) {
       if (res) {
         onlyURLArray = onlyURLArray.concat(res);
       }
-    };
+    }
     console.log("The number of URLs in this file: ", onlyURLArray.length, "\n");
 
     //goes through onlyURLArray and checks for unique URLs and puts them into uniqueURLArray
@@ -71,18 +106,20 @@ fs.readFile(options.name, 'utf8', function (err, data) {
         }
       }
     }
-    console.log("The number of UNIQUE URLs in this file: ", uniqueURLArray.length, "\n");
+    console.log(
+      "The number of UNIQUE URLs in this file: ",
+      uniqueURLArray.length,
+      "\n"
+    );
 
-    uniqueURLArray.forEach(async url => {
+    uniqueURLArray.forEach(async (url) => {
       try {
         const urlIndiv = await fetch(url, { method: "head", timeout: 13000 });
         if (urlIndiv.status === 200) {
           console.log(chalk.green("good: ", url));
-        }
-        else if (urlIndiv.status === 400 || urlIndiv.status === 404) {
+        } else if (urlIndiv.status === 400 || urlIndiv.status === 404) {
           console.log(chalk.redBright("bad: ", url));
-        }
-        else {
+        } else {
           console.log(chalk.grey("unknown: ", url));
         }
       } catch (err) {
@@ -94,14 +131,6 @@ fs.readFile(options.name, 'utf8', function (err, data) {
 
 var greeting = chalk.white.bold("lFinder is now testing: ", `${options.name}!`);
 
-//Making box for text, not necessary in the long run.
-const boxenOptions = {
-  padding: 1,
-  margin: 1,
-  borderStyle: "round",
-  borderColor: "green",
-  backgroundColor: "#555555"
-};
 const msgBox = boxen(greeting, boxenOptions);
 
 //code for displaying the statuses above


### PR DESCRIPTION
This fixes issue-9.
Added option to check the version number of the tool.
Version number is printed along with the tool name.
The output of the command is customized and printed in the box.

Usage:
lFinder -v or lFinder --version
